### PR TITLE
docs(wiki): sync local wiki with remote

### DIFF
--- a/docs/wiki/Observability-and-Metrics.md
+++ b/docs/wiki/Observability-and-Metrics.md
@@ -48,13 +48,22 @@ PSI spikes aligned with journald logs for fast root-cause analysis. This view an
 
 Snapshots are checked every 15 minutes and published when visual delta exceeds 0.5%.
 
+<<<<<<< HEAD
+=======
+The three views read as a sequence: health now, drift over time, then incident explanation.
+
+>>>>>>> c87fdde (docs: update htop image reference)
 Recent changes:
 
 - Removed freshness redundancy from the main cockpit dashboard
 - Kept freshness only in the efficiency dashboard
 - Applied explicit dual-axis semantics for closure volume (Bytes) vs path count (Count)
+<<<<<<< HEAD
 - Visual overhaul: stat panels switched to `colorMode="background"`, timeseries use hue/opacity fills, and pressure panels are stacked with threshold zone backgrounds
 - Snapshot capture hardened for headless Chromium by applying a paint-safe panel fallback immediately before screenshots
+=======
+- Visual overhaul: stat panels switched to `colorMode="background"` (full panel coloring on thresholds), timeseries upgraded with `gradientMode="hue"` fills, pressure panels stacked with threshold zone backgrounds
+>>>>>>> c87fdde (docs: update htop image reference)
 
 The dashboards are maintained as Jsonnet sources and rendered into committed Grafana JSON. Shared panel helpers live in `config/grafana/src/lib/dashboard.libsonnet`, with a small Grafonnet-style API for stat strips, gauges, time series, rows, logs, thresholds, and value mappings.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low code risk since this only changes documentation, but it currently introduces unresolved git merge conflict markers that will break the rendered wiki page until fixed.
> 
> **Overview**
> Updates `docs/wiki/Observability-and-Metrics.md` to add a short explanatory sentence about the intended reading order of the three live dashboard views and to tweak the wording of the “Visual overhaul” recent-change note.
> 
> However, the file now contains unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and duplicated/competing bullet text, which should be resolved before merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7136dd54fac6cc4d22197ee1686ee50ed0d35de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->